### PR TITLE
fix load echarts

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -10,7 +10,7 @@
 </style>
 
 <script>
-import echarts from 'echarts/lib/echarts'
+import echarts from 'echarts'
 import debounce from 'lodash/debounce'
 import { addListener, removeListener } from 'resize-detector'
 


### PR DESCRIPTION
for `Error: Component series. not exists. Load it first`